### PR TITLE
Display the author's date on the popup, not the committer's date.

### DIFF
--- a/git-messenger.el
+++ b/git-messenger.el
@@ -186,7 +186,7 @@ and menus.")
         (hg (git-messenger:hg-commit-message commit-id))))))
 
 (defun git-messenger:commit-date (commit-id)
-  (let ((args (list "--no-pager" "show" "--pretty=%cd" commit-id)))
+  (let ((args (list "--no-pager" "show" "--pretty=%ad" commit-id)))
     (with-temp-buffer
       (unless (zerop (git-messenger:execute-command 'git args t))
         (error "Failed 'git show'"))


### PR DESCRIPTION
There is currently a mismatch of data displayed on the popup, when a commit's author is different than the committer you will see the author's name displayed, but the committer's date. This change modifies the git date function so it obtains the commit author's date which matches the name shown on the popup.

For instance:
If Bob creates a commit on a branch on 2/2/17, then on 3/3/17, Jim rebases the branch before merging it, the resulting commit will have the following values:

**Author:** Bob
**Author Date:** 2/2/17
**Committer:** Jim
**Committer Date:** 3/3/17

What I expect to see in a git messenger popup is:

**Author:** Bob
**Date:** 2/2/17

However, what I do see is this:

**Author:** Bob
**Date:** 3/3/17

This change will ensure the the date Bob made the change is the date shown in the popup.